### PR TITLE
Make Markdown Links Open in New Tab

### DIFF
--- a/src/lib/components/AtlasMarkdown.svelte
+++ b/src/lib/components/AtlasMarkdown.svelte
@@ -1,8 +1,17 @@
 <script lang="ts">
-    import { marked } from 'marked';
+    import { marked, Renderer } from 'marked';
     import DOMPurify from 'isomorphic-dompurify';
+
+    // Generate all links with blank target, allows open in new tab on click.
+    const renderer = new Renderer();
+    const linkRenderer = renderer.link;
+    renderer.link = function (href, title, text) {
+        const html = linkRenderer.call(renderer, href, title, text);
+        return html.replace(/^<a /, '<a target="_blank" rel="nofollow" ');
+    };
 
     export let text: string;
 </script>
 
-{@html DOMPurify.sanitize(marked(text))}
+<!-- Add the target attribute to the sanitizer so we don't trim it away. -->
+{@html DOMPurify.sanitize(marked(text, { renderer, breaks: true }), { ADD_ATTR: ['target'] })}


### PR DESCRIPTION
This PR enforces all generated markdown links to open in a new tab. The current behaviour just redirects the user, so this should hopefully provide a better user experience.

This addresses #7 